### PR TITLE
Add additional information to QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ require 'prawn/swiss_qr_bill'
   amount: 9.90,
   currency: 'CHF',
   reference: '00 00000 00000 02202 20202 99991',
-  reference_type: 'QRR'
+  reference_type: 'QRR',
+  unstructured_message: 'Bill number 2202.20202.9999',
+  bill_information: '//S1/10/2202202029999/11/220819'
 }
 
 Prawn::Document.generate('output.pdf', page_size: 'A4') do

--- a/lib/prawn/swiss_qr_bill/qr/data.rb
+++ b/lib/prawn/swiss_qr_bill/qr/data.rb
@@ -68,6 +68,7 @@ module Prawn
           # additional:
 
           bill_information: Field.new(nil, nil, true),
+          additional_information: Field.new(nil, nil, true),
           # key-value pairs:
           alternative_parameters: Field.new(nil, nil, true)
         }.freeze

--- a/lib/prawn/swiss_qr_bill/qr/data.rb
+++ b/lib/prawn/swiss_qr_bill/qr/data.rb
@@ -64,11 +64,7 @@ module Prawn
           unstructured_message: Field.new,
           # fixed: EPD
           trailer: Field.new('EPD'),
-
-          # additional:
-
           bill_information: Field.new(nil, nil, true),
-          additional_information: Field.new(nil, nil, true),
           # key-value pairs:
           alternative_parameters: Field.new(nil, nil, true)
         }.freeze

--- a/lib/prawn/swiss_qr_bill/sections/payment_information.rb
+++ b/lib/prawn/swiss_qr_bill/sections/payment_information.rb
@@ -13,7 +13,7 @@ module Prawn
           box do
             draw_payable_to
             draw_reference if @data.key?(:reference)
-            draw_additional_information if @data.key?(:additional_information)
+            draw_additional_information if @data.key?(:unstructured_message) || @data.key?(:bill_information)
             draw_payable_by
           end
         end
@@ -37,7 +37,7 @@ module Prawn
 
         def draw_additional_information
           label I18n.t('additional_info', scope: i18n_scope)
-          content @data[:additional_information]
+          content [@data[:unstructured_message], @data[:bill_information]].join(' ')
 
           line_spacing
         end

--- a/lib/prawn/swiss_qr_bill/sections/qr_code.rb
+++ b/lib/prawn/swiss_qr_bill/sections/qr_code.rb
@@ -36,7 +36,8 @@ module Prawn
           amount: [:amount],
           currency: [:currency],
           reference: [:reference],
-          reference_type: [:reference_type]
+          reference_type: [:reference_type],
+          additional_information: [:additional_information]
         }.freeze
 
         def draw

--- a/lib/prawn/swiss_qr_bill/sections/qr_code.rb
+++ b/lib/prawn/swiss_qr_bill/sections/qr_code.rb
@@ -37,7 +37,8 @@ module Prawn
           currency: [:currency],
           reference: [:reference],
           reference_type: [:reference_type],
-          additional_information: [:additional_information]
+          unstructured_message: [:unstructured_message],
+          bill_information: [:bill_information]
         }.freeze
 
         def draw

--- a/spec/support/bill_data.yml
+++ b/spec/support/bill_data.yml
@@ -19,10 +19,8 @@ bill_data:
     currency: CHF
     reference: 00 00000 00000 02202 20202 99991
     reference_type: QRR
-    additional_information: |-
-      Auftrag vom 15.06.2020
-      //S1/10/10201409/11/170309/20/14000000/
-      30/106017086
+    unstructured_message: Auftrag vom 15.06.2020
+    bill_information: //S1/10/10201409/11/170309/20/14000000/30/106017086
   no_amount:
     creditor:
       iban: CH08 3080 8004 1110 4136 9
@@ -42,10 +40,8 @@ bill_data:
     currency: CHF
     reference: 00 00000 00000 02202 20202 99991
     reference_type: QRR
-    additional_information: |-
-      Auftrag vom 15.06.2020
-      //S1/10/10201409/11/170309/20/14000000/
-      30/106017086
+    unstructured_message: Auftrag vom 15.06.2020
+    bill_information: //S1/10/10201409/11/170309/20/14000000/30/106017086
   no_reference:
     creditor:
       iban: CH08 3080 8004 1110 4136 9
@@ -64,10 +60,8 @@ bill_data:
         country: CH
     amount: 9.90
     currency: CHF
-    additional_information: |-
-      Auftrag vom 15.06.2020
-      //S1/10/10201409/11/170309/20/14000000/
-      30/106017086
+    unstructured_message: Auftrag vom 15.06.2020
+    bill_information: //S1/10/10201409/11/170309/20/14000000/30/106017086
   no_additional_information:
     creditor:
       iban: CH08 3080 8004 1110 4136 9
@@ -143,10 +137,8 @@ bill_data:
     currency: CHF
     reference: 00 00000 00000 02202 20202 99991
     reference_type: QRR
-    additional_information: |-
-      Auftrag vom 15.06.2020
-      //S1/10/10201409/11/170309/20/14000000/
-      30/106017086
+    unstructured_message: Auftrag vom 15.06.2020
+    bill_information: //S1/10/10201409/11/170309/20/14000000/30/106017086
   scor_ref:
     creditor:
       iban: CH58 0079 1123 0008 8901 2


### PR DESCRIPTION
The additional information seems composed in 3 parts: Unstructured message + Trailer (always `EPD`) + Bill information. This PR allows to show the unstructured message or/and the bill information and updates the QR-Code in consequence.