### PR TITLE
fix currency support in bill_data

### DIFF
--- a/lib/prawn/swiss_qr_bill/sections/payment_amount.rb
+++ b/lib/prawn/swiss_qr_bill/sections/payment_amount.rb
@@ -40,7 +40,7 @@ module Prawn
           doc.bounding_box([doc.bounds.left, doc.bounds.top],
                            width: CURRENCY_WIDTH, height: specs.height) do
             label I18n.t('currency', scope: i18n_scope)
-            content 'CHF'
+            content @data.fetch(:currency, 'CHF')
           end
         end
 

--- a/lib/prawn/swiss_qr_bill/sections/receipt_amount.rb
+++ b/lib/prawn/swiss_qr_bill/sections/receipt_amount.rb
@@ -38,7 +38,7 @@ module Prawn
           doc.bounding_box([doc.bounds.left, doc.bounds.top],
                            width: CURRENCY_WIDTH, height: specs.height) do
             doc.pad_top(1.4) { label I18n.t('currency', scope: i18n_scope) }
-            doc.pad_top(2.5) { content 'CHF' }
+            doc.pad_top(2.5) { content @data.fetch(:currency, 'CHF') }
           end
         end
 

--- a/spec/features/pdf_generation_spec.rb
+++ b/spec/features/pdf_generation_spec.rb
@@ -90,4 +90,12 @@ describe 'PDF generation' do
       expect(reader_for_bill.pages.length).to eq(1)
     end
   end
+
+  context 'when currency EUR' do
+    let(:bill_data) { DataManager.build_bill(:default).merge(currency: 'EUR') }
+
+    it 'generates a correct pdf' do
+      expect(reader_for_bill.pages[0].text).to include('EUR').twice
+    end
+  end
 end


### PR DESCRIPTION
According to the documentation, `currency` can be specified within the `bill_data`, but previously, it had no impact since 'CHF' was hardcoded. This fix utilizes the currency value and defaults to 'CHF' when the currency is not specified.