### PR TITLE
fix: drawing structured addresses

### DIFF
--- a/lib/prawn/swiss_qr_bill/sections/section.rb
+++ b/lib/prawn/swiss_qr_bill/sections/section.rb
@@ -68,10 +68,13 @@ module Prawn
         def build_address(address)
           [
             address[:name],
-            address[:line1],
-            address[:line2],
+            if address[:type] == 'S'
+              [address[:line1], address[:line2]].compact.join(' ')
+            else
+              [address[:line1], address[:line2]]
+            end,
             [address[:postal_code], address[:city]].compact.join(' ')
-          ].compact.join("\n")
+          ].flatten.compact.join("\n")
         end
 
         def load_specs

--- a/spec/prawn/swiss_qr_bill/bill_spec.rb
+++ b/spec/prawn/swiss_qr_bill/bill_spec.rb
@@ -25,5 +25,33 @@ describe Prawn::SwissQRBill::Bill do
     it 'can be drawn through prawn' do
       document.swiss_qr_bill(bill_full)
     end
+
+    context 'with structured address (address type S)' do
+      let(:s_type_address) { DataManager.build_bill(:s_type_address) }
+
+      it 'combines `line1` (street name) and `line2` (street number) on a single line' do
+        described_class.new(document, s_type_address).draw
+
+        pdf_text = PDF::Reader.new(StringIO.new(document.render)).page(1).text
+
+        expect(pdf_text).to include('Schybenächerweg 553')
+          .and include('Musterstrasse 1')
+      end
+    end
+
+    context 'with unstructured address (address type K)' do
+      let(:k_type_address) { DataManager.build_bill(:k_type_address) }
+
+      it 'draws `line1` (street name + number ) and `line2` (postal_code + city) on separate lines' do
+        described_class.new(document, k_type_address).draw
+
+        pdf_text = PDF::Reader.new(StringIO.new(document.render)).page(1).text
+
+        expect(pdf_text).to include("Musterstrasse 123\n")
+          .and include("8000 Seldwyla\n")
+          .and include("Simonstrasse 1\n")
+          .and include("5000 Aarau\n")
+      end
+    end
   end
 end

--- a/spec/support/bill_data.yml
+++ b/spec/support/bill_data.yml
@@ -5,7 +5,8 @@ bill_data:
       address:
         type: S
         name: Mischa Schindowski
-        line1: Schybenächerweg 553
+        line1: Schybenächerweg
+        line2: 553
         postal_code: 5324
         city: Full-Reuenthal
         country: CH
@@ -13,7 +14,8 @@ bill_data:
       address:
         type: S
         name: Simon Muster
-        line1: Musterstrasse 1
+        line1: Musterstrasse
+        line2: 1
         postal_code: 8000
         city: Zürich
         country: CH
@@ -111,7 +113,8 @@ bill_data:
       address:
         type: S
         name: Mischa Schindowski
-        line1: Schybenächerweg 553
+        line1: Schybenächerweg
+        line2: 553
         postal_code: 5324
         city: Full-Reuenthal
         country: CH
@@ -119,7 +122,8 @@ bill_data:
       address:
         type: S
         name: Simon Muster
-        line1: Musterstrasse 1
+        line1: Musterstrasse
+        line2: 1
         postal_code: 8000
         city: Zürich
         country: CH
@@ -202,3 +206,39 @@ bill_data:
     currency: CHF
     reference: RF18 5390 0754 7034
     reference_type: SCOR
+  s_type_address:
+    creditor:
+      iban: CH58 0079 1123 0008 8901 2
+      address:
+        type: S
+        name: Mischa Schindowski
+        line1: Schybenächerweg
+        line2: 553
+        postal_code: 5324
+        city: Full-Reuenthal
+        country: CH
+    debtor:
+      address:
+        type: S
+        name: Simon Muster
+        line1: Musterstrasse
+        line2: 1
+        postal_code: 8000
+        city: Zürich
+        country: CH
+  k_type_address:
+    creditor:
+      iban: CH58 0079 1123 0008 8901 2
+      address:
+        type: K
+        name: Max Muster & Söhne
+        line1: Musterstrasse 123
+        line2: 8000 Seldwyla
+        country: CH
+    debtor:
+      address:
+        type: K
+        name: Simon Muster
+        line1: Simonstrasse 1
+        line2: 5000 Aarau
+        country: CH


### PR DESCRIPTION
According to the [Swiss QR-bill specification][1], a structured address (type S) has `line1` representing the _street name_ and `line2` representing the _street number_. When a structured address is provided, the library currently prints `line1` and `line2` on two separate lines. However, for type S addresses, `line1` and `line2` should be printed combined on a single line.

While it is possible to provide the _street name_ and _number_ combined in `line1` as a workaround, most e-banking software expects these to be separate. Otherwise, the software may not populate its form correctly, causing unnecessary friction in the payment process.

![Screenshot 2024-09-02 at 11 33 30](https://github.com/user-attachments/assets/79e21e64-42b3-439e-b8f3-8e3a0b4b9e52)

[1]: https://www.six-group.com/dam/download/banking-services/standardization/qr-bill/ig-qr-bill-v2.2-en.pdf